### PR TITLE
Feature furniture place event

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,16 +67,16 @@ dependencies {
     compileOnly group: 'me.clip', name: 'placeholderapi', version: '2.11.1'
     compileOnly group: 'com.github.BeYkeRYkt', name: 'LightAPI', version: '5.2.0-Bukkit'
     compileOnly group: 'me.gabytm.util', name: 'actions-core', version: actionsVersion
-    compileOnly group: 'org.springframework', name: 'spring-expression', version: '5.3.16'
+    compileOnly group: 'org.springframework', name: 'spring-expression', version: '5.3.20'
     compileOnly group: 'io.lumine', name: 'Mythic-Dist', version: '5.0.2-SNAPSHOT'
     compileOnly group: 'com.sk89q.worldedit', name: 'worldedit-bukkit', version: '7.2.0'
     compileOnly fileTree(dir: 'libs/compile', include: ['*.jar'])
     implementation fileTree(dir: 'libs/implement', include: ['*.jar'])
-    implementation group: 'org.bstats', name: 'bstats-bukkit', version: '2.2.1'
+    implementation group: 'org.bstats', name: 'bstats-bukkit', version: '3.0.0'
     implementation group: 'com.github.oraxen', name: 'protectionlib', version: '1.1.1'
     implementation group: 'net.kyori', name: 'adventure-text-minimessage', version: '4.2.0-SNAPSHOT'
     implementation group: 'net.kyori', name: 'adventure-platform-bukkit', version: '4.0.0'
-    implementation group: 'com.github.stefvanschie.inventoryframework', name: 'IF', version: '0.10.0'
+    implementation group: 'com.github.stefvanschie.inventoryframework', name: 'IF', version: '0.10.6'
     implementation group: 'dev.jorel', name: 'commandapi-shade', version: '8.4.0-SNAPSHOT'
     implementation "com.jeff_media:CustomBlockData:2.0.0"
     implementation "com.jeff_media:MorePersistentDataTypes:2.3.1"

--- a/src/main/java/io/th0rgal/oraxen/events/OraxenFurniturePlaceEvent.java
+++ b/src/main/java/io/th0rgal/oraxen/events/OraxenFurniturePlaceEvent.java
@@ -1,0 +1,58 @@
+package io.th0rgal.oraxen.events;
+
+import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.NotNull;
+
+public class OraxenFurniturePlaceEvent extends Event implements Cancellable {
+
+    FurnitureMechanic furnitureMechanic;
+
+    Player player;
+
+    Block block;
+
+    boolean isCancelled;
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    public OraxenFurniturePlaceEvent(FurnitureMechanic mechanic, Block block, Player player){
+        this.furnitureMechanic = mechanic;
+        this.player = player;
+        this.block = block;
+        this.isCancelled = false;
+    }
+
+
+    @Override
+    public boolean isCancelled() {
+        return isCancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        isCancelled = cancelled;
+    }
+
+    @NotNull
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public FurnitureMechanic getFurnitureMechanic() {
+        return furnitureMechanic;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public Block getBlock() {
+        return block;
+    }
+}

--- a/src/main/java/io/th0rgal/oraxen/events/OraxenFurniturePlaceEvent.java
+++ b/src/main/java/io/th0rgal/oraxen/events/OraxenFurniturePlaceEvent.java
@@ -2,6 +2,7 @@ package io.th0rgal.oraxen.events;
 
 import io.th0rgal.oraxen.mechanics.provided.gameplay.furniture.FurnitureMechanic;
 import org.bukkit.block.Block;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -16,15 +17,22 @@ public class OraxenFurniturePlaceEvent extends Event implements Cancellable {
 
     Block block;
 
+    ItemFrame itemFrame;
+
     boolean isCancelled;
+
+    // this event should fire twice, once before the block and itemframe are created, and once after. boolean postCreation is false before the BlockPlaceEvent and true after.
+    boolean postCreation;
 
     private static final HandlerList HANDLERS = new HandlerList();
 
-    public OraxenFurniturePlaceEvent(FurnitureMechanic mechanic, Block block, Player player){
+    public OraxenFurniturePlaceEvent(FurnitureMechanic mechanic, Block block, ItemFrame itemFrame,  Player player, boolean postCreation){
         this.furnitureMechanic = mechanic;
         this.player = player;
         this.block = block;
         this.isCancelled = false;
+        this.postCreation = postCreation;
+        this.itemFrame = itemFrame;
     }
 
 
@@ -54,5 +62,13 @@ public class OraxenFurniturePlaceEvent extends Event implements Cancellable {
 
     public Block getBlock() {
         return block;
+    }
+
+    public ItemFrame getItemFrame() {
+        return itemFrame;
+    }
+
+    public boolean isPostCreation() {
+        return postCreation;
     }
 }

--- a/src/main/java/io/th0rgal/oraxen/events/OraxenFurniturePlaceEvent.java
+++ b/src/main/java/io/th0rgal/oraxen/events/OraxenFurniturePlaceEvent.java
@@ -47,8 +47,8 @@ public class OraxenFurniturePlaceEvent extends Event implements Cancellable {
     }
 
     @NotNull
-    @Override
-    public HandlerList getHandlers() {
+    public HandlerList getHandlers() { return getHandlerList(); }
+    public static HandlerList getHandlerList() {
         return HANDLERS;
     }
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -201,7 +201,7 @@ public class FurnitureListener implements Listener {
             Message.NOT_ENOUGH_SPACE.send(player);
         }
 
-        final OraxenFurniturePlaceEvent preCreationEvent = new OraxenFurniturePlaceEvent(mechanic, target, player, false);
+        final OraxenFurniturePlaceEvent preCreationEvent = new OraxenFurniturePlaceEvent(mechanic, target, null, player, false);
 
         Bukkit.getPluginManager().callEvent(preCreationEvent);
 
@@ -216,12 +216,12 @@ public class FurnitureListener implements Listener {
             return;
         }
 
-        mechanic.place(rotation, yaw, event.getBlockFace(), target.getLocation(), item);
+        ItemFrame itemframe = mechanic.place(rotation, yaw, event.getBlockFace(), target.getLocation(), item);
         Utils.sendAnimation(player, event.getHand());
         if (!player.getGameMode().equals(GameMode.CREATIVE))
             item.setAmount(item.getAmount() - 1);
 
-        final OraxenFurniturePlaceEvent postCreationEvent = new OraxenFurniturePlaceEvent(mechanic, target, player, true);
+        final OraxenFurniturePlaceEvent postCreationEvent = new OraxenFurniturePlaceEvent(mechanic, target, itemframe, player, true);
 
         Bukkit.getPluginManager().callEvent(postCreationEvent);
 

--- a/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
+++ b/src/main/java/io/th0rgal/oraxen/mechanics/provided/gameplay/furniture/FurnitureListener.java
@@ -5,6 +5,7 @@ import io.th0rgal.oraxen.OraxenPlugin;
 import io.th0rgal.oraxen.config.Message;
 import io.th0rgal.oraxen.events.OraxenFurnitureBreakEvent;
 import io.th0rgal.oraxen.events.OraxenFurnitureInteractEvent;
+import io.th0rgal.oraxen.events.OraxenFurniturePlaceEvent;
 import io.th0rgal.oraxen.items.OraxenItems;
 import io.th0rgal.oraxen.mechanics.MechanicFactory;
 import io.th0rgal.oraxen.mechanics.provided.gameplay.noteblock.NoteBlockMechanic;
@@ -166,6 +167,7 @@ public class FurnitureListener implements Listener {
             }
         }
 
+
         if (target == null) return;
         final BlockData currentBlockData = target.getBlockData();
         FurnitureMechanic mechanic = getMechanic(item, player, target);
@@ -199,6 +201,14 @@ public class FurnitureListener implements Listener {
             Message.NOT_ENOUGH_SPACE.send(player);
         }
 
+        final OraxenFurniturePlaceEvent preCreationEvent = new OraxenFurniturePlaceEvent(mechanic, target, player, false);
+
+        Bukkit.getPluginManager().callEvent(preCreationEvent);
+
+        if(preCreationEvent.isCancelled()){
+            blockPlaceEvent.setCancelled(true);
+        }
+
         Bukkit.getPluginManager().callEvent(blockPlaceEvent);
 
         if (!blockPlaceEvent.canBuild() || blockPlaceEvent.isCancelled()) {
@@ -210,6 +220,11 @@ public class FurnitureListener implements Listener {
         Utils.sendAnimation(player, event.getHand());
         if (!player.getGameMode().equals(GameMode.CREATIVE))
             item.setAmount(item.getAmount() - 1);
+
+        final OraxenFurniturePlaceEvent postCreationEvent = new OraxenFurniturePlaceEvent(mechanic, target, player, true);
+
+        Bukkit.getPluginManager().callEvent(postCreationEvent);
+
     }
 
     private Block getTarget(Block placedAgainst, BlockFace blockFace) {


### PR DESCRIPTION
Implemented OraxenFurniturePlaceEvent. Fires twice, once before and once after the block and itemframe are created with a boolean 'postCreation' to signify which.